### PR TITLE
(feat): adding state as the identifying factor for first login

### DIFF
--- a/pkg/manage/manager.go
+++ b/pkg/manage/manager.go
@@ -111,6 +111,7 @@ func (m *Manager) LocalLoginUser(username string) error {
 		return err
 	}
 	storedUser.LoggedIn = true
+	storedUser.State = models.StateActive
 	return m.userStore.UpdateUser(storedUser)
 }
 

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -83,13 +83,11 @@ type PublicUserInfo struct {
 type State string
 
 const (
-	//StateCreating means this entry is being created yet
-	StateCreating State = "creating"
-	//StateActive means this entry is active
+	//StateCreated means admin has created the user but the user has still not logged in
+	StateCreated State = "created"
+	//StateActive means user has logged in successfully
 	StateActive State = "active"
-	//StateRemoving means this entry is being removed
-	StateRemoving State = "removing"
-	//StateRemoved means this entry has been removed
+	//StateRemoved means user has been deleted
 	StateRemoved State = "removed"
 )
 

--- a/pkg/oauth/providers/github.go
+++ b/pkg/oauth/providers/github.go
@@ -31,6 +31,7 @@ func getUserFromToken(c *gin.Context, token *oauth2.Token) (*models.UserCredenti
 		Email:        githubUser.Email,
 		Kind:         models.GithubAuth,
 		Role:         models.RoleUser,
+		State:        models.StateActive,
 		SocialAuthID: githubUser.GetID(),
 		LoggedIn:     true,
 		CreatedAt:    &currTime,

--- a/versionedController/v1/user/user.go
+++ b/versionedController/v1/user/user.go
@@ -70,6 +70,7 @@ func (user *UserController) Post(c *gin.Context) {
 	userModel := models.UserCredentials(*user.model)
 	userModel.Kind = models.LocalAuth
 	userModel.Role = models.RoleUser
+	userModel.State = models.StateCreated
 	controller.Server.CreateRequest(c, &userModel)
 	return
 }


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR does following

- Initializes the state to `Created` whenever a user is created by the admin

- Changes the state to `Active` when the user signs in for the first time

- Directly initializes state to `Active` if the user opts for github auth