### PR TITLE
adding db authentication as optional thing

### DIFF
--- a/pkg/store/user.go
+++ b/pkg/store/user.go
@@ -31,14 +31,16 @@ func NewUserStore(cfg *Config, ucfgs ...*UserConfig) (*UserStore, error) {
 		return nil, err
 	}
 
-	cred := mgo.Credential{
-		Username: types.DBUser,
-		Password: types.DBPassword,
-	}
-	err = session.Login(&cred)
-	if err != nil {
-		log.Errorln("Eror connecting database error", err)
-		return nil, err
+	if types.DBUser != "" && types.DBPassword != "" {
+		cred := mgo.Credential{
+			Username: types.DBUser,
+			Password: types.DBPassword,
+		}
+		err = session.Login(&cred)
+		if err != nil {
+			log.Errorln("Eror connecting database error", err)
+			return nil, err
+		}
 	}
 
 	return NewUserStoreWithSession(session, cfg.DB, ucfgs...)


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>
This PR removes the necessity of the DB authentication (puts it as the optional one)
If the env var `DB_USER` or `DB_PASSWORD` appears to be empty . Login to mongo won't happen then.