### PR TITLE
(fix): no response on `/v1/configuration`

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -37,6 +37,7 @@ var (
 		"/v1" + v1.EmailRoute:         {http.MethodGet},
 		"/v1" + "/oauth":              {http.MethodGet},
 		"/v1" + v1.ConfigurationRoute: {http.MethodGet},
+		"/v1" + healthCheckRoute:      {http.MethodGet},
 	}
 )
 

--- a/versionedController/v1/configuration/configuration.go
+++ b/versionedController/v1/configuration/configuration.go
@@ -134,7 +134,6 @@ func (configurationController *Controller) Get(c *gin.Context) {
 	tokenString, err := getTokenFromHeader(c.Request)
 	if err != nil {
 		log.Errorln("Invalid Token: Unable to parse jwt")
-		return
 	}
 
 	userInfo, err := controller.Server.GetUserFromToken(tokenString)


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR contains fixes following bugs -

- No response without jwt on below paths 
  -  `/v1/configuration`
  - `/v1/health`
  
- Added `/v1/health` in unauthenticated links
- Removed return statement as it was blocking the response