### PR TITLE
(fix): Same username assigned to different users

### DIFF
--- a/versionedController/v1/email/email.go
+++ b/versionedController/v1/email/email.go
@@ -12,7 +12,6 @@ import (
 type EmailController struct {
 	controller.GenericController
 	routePath string
-	model     *Model
 }
 
 //Model ...
@@ -24,13 +23,13 @@ type Model struct {
 func New() *EmailController {
 	return &EmailController{
 		routePath: controller.EmailRoute,
-		model:     &Model{},
 	}
 }
 
 //Post send the verification link to an email address
 func (emailController *EmailController) Post(c *gin.Context) {
-	err := c.BindJSON(emailController.model)
+	emailModel := &Model{}
+	err := c.BindJSON(emailModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -39,7 +38,7 @@ func (emailController *EmailController) Post(c *gin.Context) {
 		return
 	}
 
-	controller.Server.SendVerificationLink(c, emailController.model.Email)
+	controller.Server.SendVerificationLink(c, emailModel.Email)
 }
 
 //Get verifies the email by a link

--- a/versionedController/v1/login/login.go
+++ b/versionedController/v1/login/login.go
@@ -16,7 +16,6 @@ import (
 type LoginController struct {
 	controller.GenericController
 	routePath string
-	model     *Model
 }
 
 // Model defines the json struct in which the request will be parsed
@@ -29,7 +28,6 @@ type Model struct {
 func New() *LoginController {
 	return &LoginController{
 		routePath: controller.TokenRoute,
-		model:     &Model{},
 	}
 }
 
@@ -41,7 +39,8 @@ func init() {
 
 // Post lets a user login into the kubera-core
 func (login *LoginController) Post(c *gin.Context) {
-	err := c.BindJSON(login.model)
+	loginModel := &Model{}
+	err := c.BindJSON(loginModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -50,7 +49,7 @@ func (login *LoginController) Post(c *gin.Context) {
 		return
 	}
 
-	controller.Server.LocalLoginRequest(c, login.model.Username, login.model.Password)
+	controller.Server.LocalLoginRequest(c, loginModel.Username, loginModel.Password)
 	return
 }
 

--- a/versionedController/v1/password/password.go
+++ b/versionedController/v1/password/password.go
@@ -12,7 +12,6 @@ import (
 type PasswordController struct {
 	controller.GenericController
 	routePath string
-	model     *Model
 }
 
 //Model ...
@@ -25,13 +24,13 @@ type Model struct {
 func New() *PasswordController {
 	return &PasswordController{
 		routePath: controller.PasswordRoute,
-		model:     &Model{},
 	}
 }
 
 //Put updates the password of the concerned user
 func (password *PasswordController) Put(c *gin.Context) {
-	err := c.BindJSON(password.model)
+	passwordModel := &Model{}
+	err := c.BindJSON(passwordModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -40,7 +39,7 @@ func (password *PasswordController) Put(c *gin.Context) {
 		return
 	}
 
-	controller.Server.UpdatePasswordRequest(c, password.model.OldPassword, password.model.NewPassword)
+	controller.Server.UpdatePasswordRequest(c, passwordModel.OldPassword, passwordModel.NewPassword)
 	return
 }
 

--- a/versionedController/v1/user/user.go
+++ b/versionedController/v1/user/user.go
@@ -14,20 +14,19 @@ import (
 type UserController struct {
 	controller.GenericController
 	routePath string
-	model     *models.UserCredentials
 }
 
 // New creates a new User
 func New() *UserController {
 	return &UserController{
 		routePath: controller.UserRoute,
-		model:     &models.UserCredentials{},
 	}
 }
 
 // Put updates a user details
 func (user *UserController) Put(c *gin.Context) {
-	err := c.BindJSON(user.model)
+	userModel := &models.UserCredentials{}
+	err := c.BindJSON(userModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -36,14 +35,14 @@ func (user *UserController) Put(c *gin.Context) {
 		return
 	}
 
-	userModel := models.UserCredentials(*user.model)
-	controller.Server.UpdateUserDetailsRequest(c, &userModel)
+	controller.Server.UpdateUserDetailsRequest(c, userModel)
 	return
 }
 
 //Patch updates the password of concerned user ggiven that request should be sent by admin
 func (user *UserController) Patch(c *gin.Context) {
-	err := c.BindJSON(user.model)
+	userModel := &models.UserCredentials{}
+	err := c.BindJSON(userModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -52,13 +51,14 @@ func (user *UserController) Patch(c *gin.Context) {
 		return
 	}
 
-	controller.Server.ResetPasswordRequest(c, user.model.GetPassword(), user.model.GetUserName())
+	controller.Server.ResetPasswordRequest(c, userModel.GetPassword(), userModel.GetUserName())
 	return
 }
 
 //Post creates a user, request should be sent by admin
 func (user *UserController) Post(c *gin.Context) {
-	err := c.BindJSON(user.model)
+	userModel := &models.UserCredentials{}
+	err := c.BindJSON(userModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -67,11 +67,10 @@ func (user *UserController) Post(c *gin.Context) {
 		return
 	}
 
-	userModel := models.UserCredentials(*user.model)
 	userModel.Kind = models.LocalAuth
 	userModel.Role = models.RoleUser
 	userModel.State = models.StateCreated
-	controller.Server.CreateRequest(c, &userModel)
+	controller.Server.CreateRequest(c, userModel)
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR fixes following bugs -

- We are having 
```
type UserController struct {
	controller.GenericController
	routePath string
	model     *models.UserCredentials
}
```
as the struct so because of this model is a global variable and is overridden for every request due to which fields of the current request retains and sometimes can get assigned to the new request even if it is from a different user