### PR TITLE
(refactor): changing PublicUserInfo to UserCredentials

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/manager/jwtmanager/jwt.go
+++ b/manager/jwtmanager/jwt.go
@@ -27,16 +27,16 @@ var (
 )
 
 // ParseToken validates the token
-func ParseToken(userStore *store.UserStore, accessGenerate *generates.JWTAccessGenerate, tokenString string) (userInfo *models.PublicUserInfo, err error) {
-	userInfo, err = accessGenerate.Parse(tokenString)
+func ParseToken(userStore *store.UserStore, accessGenerate *generates.JWTAccessGenerate, tokenString string) (*models.UserCredentials, error) {
+	claimedUser, err := accessGenerate.Parse(tokenString)
 	if err != nil {
 		return nil, err
 	}
-	user, err := usermanager.GetUserByUID(userStore, userInfo.GetUID())
+	user, err := usermanager.GetUserByUID(userStore, claimedUser.GetUID())
 	if err != nil {
 		return nil, err
 	}
-	return user.GetPublicInfo(), nil
+	return user, nil
 }
 
 // GenerateAuthToken generate the authorization token(code)

--- a/manager/usermanager/updateUser.go
+++ b/manager/usermanager/updateUser.go
@@ -2,7 +2,6 @@ package usermanager
 
 import (
 	"github.com/globalsign/mgo/bson"
-	"github.com/imdario/mergo"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/mayadata-io/kubera-auth/pkg/errors"
@@ -13,24 +12,13 @@ import (
 
 // UpdateUserDetails get the user information
 func UpdateUserDetails(userStore *store.UserStore, user *models.UserCredentials) (*models.PublicUserInfo, error) {
-	storedUser, err := userStore.GetUserByID(user.GetID())
-	if err != nil {
-		return nil, errors.ErrInvalidUser
-	}
-
-	// It will override the `storedUser` with values filled in `user` and preserve the other values of `storedUser`
-	err = mergo.Merge(storedUser, user, mergo.WithOverride)
-	if err != nil {
-		return nil, err
-	}
-
 	// This is just for github auth. Will implement a switch  case here once we have a self signup
-	if storedUser.OnBoardingState == models.BoardingStateEmailVerified && storedUser.Kind == models.GithubAuth {
-		storedUser.OnBoardingState = models.BoardingStateVerifiedAndComplete
+	if user.OnBoardingState == models.BoardingStateEmailVerified && user.Kind == models.GithubAuth {
+		user.OnBoardingState = models.BoardingStateVerifiedAndComplete
 	}
 
-	err = userStore.UpdateUser(storedUser)
-	return storedUser.GetPublicInfo(), err
+	err := userStore.UpdateUser(user)
+	return user.GetPublicInfo(), err
 }
 
 // UpdatePassword get the user information

--- a/pkg/generates/jwt_access.go
+++ b/pkg/generates/jwt_access.go
@@ -140,19 +140,19 @@ func (a *JWTAccessGenerate) isHs() bool {
 }
 
 // Parse parses a UserName from a token
-func (a *JWTAccessGenerate) Parse(tokenString string) (*models.PublicUserInfo, error) {
+func (a *JWTAccessGenerate) Parse(tokenString string) (*models.UserCredentials, error) {
 	token, err := a.parseToken(tokenString)
 	if err != nil {
 		return nil, err
 	}
 
-	var userInfo *models.PublicUserInfo = new(models.PublicUserInfo)
+	var user *models.UserCredentials = new(models.UserCredentials)
 
 	if claims, ok := token.Claims.(*JWTAccessClaims); ok && token.Valid {
-		userInfo.Role = claims.Role
-		userInfo.UID = &claims.UID
-		userInfo.ID = claims.ID
-		return userInfo, nil
+		user.Role = claims.Role
+		user.UID = &claims.UID
+		user.ID = claims.ID
+		return user, nil
 	}
 	return nil, errors.ErrInvalidAccessToken
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -102,14 +102,14 @@ func (s *Server) SocialLoginRequest(c *gin.Context, user *models.UserCredentials
 
 // LogoutRequest the authorization request handling
 func (s *Server) LogoutRequest(c *gin.Context) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
-	err := loginmanager.LogoutUser(s.userStore, jwtUserInfo.GetID())
+	err := loginmanager.LogoutUser(s.userStore, jwtUserCredentials.GetID())
 	if err != nil {
 		s.redirectError(c, err)
 		return
@@ -191,25 +191,25 @@ func (s *Server) responseErrorHandler(re *errors.Response) {
 }
 
 // GetUserFromToken gets the user from token
-func (s *Server) GetUserFromToken(token string) (*models.PublicUserInfo, error) {
+func (s *Server) GetUserFromToken(token string) (*models.UserCredentials, error) {
 	return jwtmanager.ParseToken(s.userStore, s.accessGenerate, token)
 }
 
 // UpdatePasswordRequest validates the request
 func (s *Server) UpdatePasswordRequest(c *gin.Context, oldPassword, newPassword string) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
 	if oldPassword == "" || newPassword == "" {
 		c.JSON(http.StatusBadRequest, errors.ErrInvalidRequest)
 		return
 	}
 
-	updatedUserInfo, err := usermanager.UpdatePassword(s.userStore, false, oldPassword, newPassword, jwtUserInfo.GetUID())
+	updatedUserInfo, err := usermanager.UpdatePassword(s.userStore, false, oldPassword, newPassword, jwtUserCredentials.GetUID())
 	if err != nil {
 		s.redirectError(c, err)
 		return
@@ -219,12 +219,12 @@ func (s *Server) UpdatePasswordRequest(c *gin.Context, oldPassword, newPassword 
 
 // ResetPasswordRequest validates the request
 func (s *Server) ResetPasswordRequest(c *gin.Context, newPassword, userName string) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
 	if userName == "" || newPassword == "" {
 		c.JSON(http.StatusBadRequest, errors.ErrInvalidRequest)
@@ -233,7 +233,7 @@ func (s *Server) ResetPasswordRequest(c *gin.Context, newPassword, userName stri
 
 	var updatedUserInfo *models.PublicUserInfo
 	var err error
-	if jwtUserInfo.GetRole() == models.RoleAdmin {
+	if jwtUserCredentials.GetRole() == models.RoleAdmin {
 		updatedUserInfo, err = usermanager.UpdatePassword(s.userStore, true, "", newPassword, userName)
 		if err != nil {
 			s.redirectError(c, err)
@@ -245,14 +245,14 @@ func (s *Server) ResetPasswordRequest(c *gin.Context, newPassword, userName stri
 
 // UpdateUserDetailsRequest validates the request
 func (s *Server) UpdateUserDetailsRequest(c *gin.Context, user *models.UserCredentials) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
-	user.ID = jwtUserInfo.GetID()
+	user.ID = jwtUserCredentials.GetID()
 	updatedUserInfo, err := usermanager.UpdateUserDetails(s.userStore, user)
 	if err != nil {
 		s.redirectError(c, err)
@@ -263,12 +263,12 @@ func (s *Server) UpdateUserDetailsRequest(c *gin.Context, user *models.UserCrede
 
 // CreateRequest validates the request
 func (s *Server) CreateRequest(c *gin.Context, user *models.UserCredentials) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
 	if user.GetUserName() == "" || user.GetPassword() == "" {
 		s.redirectError(c, errors.ErrInvalidRequest)
@@ -277,7 +277,7 @@ func (s *Server) CreateRequest(c *gin.Context, user *models.UserCredentials) {
 
 	var createdUserInfo *models.PublicUserInfo
 	var err error
-	if jwtUserInfo.GetRole() == models.RoleAdmin {
+	if jwtUserCredentials.GetRole() == models.RoleAdmin {
 		createdUserInfo, err = usermanager.CreateUser(s.userStore, user)
 		if err != nil {
 			s.redirectError(c, err)
@@ -321,15 +321,15 @@ func (s *Server) GetUserByUserName(c *gin.Context, userID string) {
 
 // SendVerificationLink sends the verification link in the desired email
 func (s *Server) SendVerificationLink(c *gin.Context, email string) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
-	jwtUserInfo.Email = &email
-	updatedUserInfo, err := usermanager.UpdateUserDetails(s.userStore, jwtUserInfo.GetUserCredentials())
+	jwtUserCredentials.Email = &email
+	updatedUserInfo, err := usermanager.UpdateUserDetails(s.userStore, jwtUserCredentials)
 	if err != nil {
 		s.redirectError(c, err)
 		return
@@ -348,9 +348,9 @@ func (s *Server) SendVerificationLink(c *gin.Context, email string) {
 
 	link := types.PortalURL + "/api/auth/v1/email?access=" + tokenInfo.Access
 
-	buf, err := generates.GetEmailBody(jwtUserInfo.GetName(), link)
+	buf, err := generates.GetEmailBody(jwtUserCredentials.GetName(), link)
 	if err != nil {
-		log.Error("Error occurred while getting email body for user: " + jwtUserInfo.GetUID() + "error: " + err.Error())
+		log.Error("Error occurred while getting email body for user: " + jwtUserCredentials.GetUID() + "error: " + err.Error())
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),
 		})
@@ -359,7 +359,7 @@ func (s *Server) SendVerificationLink(c *gin.Context, email string) {
 
 	err = generates.SendEmail(email, "Email Verification", buf.String())
 	if err != nil {
-		log.Error("Error occurred while sending email for user: " + jwtUserInfo.GetUID() + "error: " + err.Error())
+		log.Error("Error occurred while sending email for user: " + jwtUserCredentials.GetUID() + "error: " + err.Error())
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),
 		})
@@ -373,17 +373,17 @@ func (s *Server) SendVerificationLink(c *gin.Context, email string) {
 
 // VerifyEmail marks a user email as verified
 func (s *Server) VerifyEmail(c *gin.Context) {
-	jwtUser, exists := c.Get(types.UserInfoKey)
+	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {
 		s.redirectError(c, errors.ErrInvalidAccessToken)
 		return
 	}
-	jwtUserInfo := jwtUser.(*models.PublicUserInfo)
+	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
-	_, _ = usermanager.UpdateUserDetails(s.userStore, jwtUserInfo.GetUserCredentials())
+	_, _ = usermanager.UpdateUserDetails(s.userStore, jwtUserCredentials)
 
 	tgr := &jwtmanager.TokenGenerateRequest{
-		UserInfo:       jwtUserInfo,
+		UserInfo:       jwtUserCredentials.GetPublicInfo(),
 		AccessTokenExp: time.Minute * 10,
 	}
 

--- a/pkg/types/default.go
+++ b/pkg/types/default.go
@@ -17,7 +17,7 @@ const (
 	DefaultAuthDB                      string        = "auth"
 	DefaultLocalAuthCollection         string        = "usercredentials"
 	GithubState                        string        = "github"
-	UserInfoKey                        string        = "userInfo"
+	JWTUserCredentialsKey              string        = "userCredentials"
 	TemplatePath                       string        = "./templates"
 	AuthHeaderKey                      string        = "Authorization"
 	AuthHeaderPrefix                   string        = "Bearer "

--- a/router/router.go
+++ b/router/router.go
@@ -136,7 +136,7 @@ func Middleware(c *gin.Context) {
 		return
 	}
 
-	userInfo, err := v1.Server.GetUserFromToken(token)
+	jwtUserCredentials, err := v1.Server.GetUserFromToken(token)
 	if err != nil {
 		c.Abort()
 		c.JSON(http.StatusUnauthorized, gin.H{
@@ -144,5 +144,5 @@ func Middleware(c *gin.Context) {
 		})
 		return
 	}
-	c.Set(types.UserInfoKey, userInfo)
+	c.Set(types.JWTUserCredentialsKey, jwtUserCredentials)
 }

--- a/versionedController/v1/configuration/configuration.go
+++ b/versionedController/v1/configuration/configuration.go
@@ -45,11 +45,11 @@ func (configurationController *Controller) Put(c *gin.Context) {
 		return
 	}
 
-	userInfo, err := controller.Server.GetUserFromToken(tokenString)
-	if err != nil || userInfo == nil {
+	jwtUserCredentials, err := controller.Server.GetUserFromToken(tokenString)
+	if err != nil || jwtUserCredentials == nil {
 		c.JSON(http.StatusUnauthorized, err.Error())
 		return
-	} else if userInfo.GetRole() != models.RoleAdmin {
+	} else if jwtUserCredentials.GetRole() != models.RoleAdmin {
 		c.JSON(http.StatusUnauthorized, err.Error())
 		return
 	}
@@ -133,8 +133,8 @@ func (configurationController *Controller) Get(c *gin.Context) {
 		log.Errorln("Invalid Token: Unable to parse jwt")
 	}
 
-	userInfo, err := controller.Server.GetUserFromToken(tokenString)
-	if err == nil && userInfo.GetRole() == models.RoleAdmin {
+	jwtUserCredentials, err := controller.Server.GetUserFromToken(tokenString)
+	if err == nil && jwtUserCredentials.GetRole() == models.RoleAdmin {
 		authData[types.GITHUB_CLIENT_ID] = controller.Server.GithubConfig.ClientID
 		authData[types.GITHUB_CLIENT_SECRET] = controller.Server.GithubConfig.ClientSecret
 	}

--- a/versionedController/v1/email/email.go
+++ b/versionedController/v1/email/email.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	log "github.com/golang/glog"
 
+	"github.com/mayadata-io/kubera-auth/pkg/types"
 	controller "github.com/mayadata-io/kubera-auth/versionedController/v1"
 )
 
@@ -45,7 +46,7 @@ func (emailController *EmailController) Post(c *gin.Context) {
 func (emailController *EmailController) Get(c *gin.Context) {
 	token := c.Query("access")
 
-	jwtUserInfo, err := controller.Server.GetUserFromToken(token)
+	jwtUserCredentials, err := controller.Server.GetUserFromToken(token)
 	if err != nil {
 		log.Error("Error occurred while parsing jwt token error: " + err.Error())
 		c.JSON(http.StatusUnauthorized, gin.H{
@@ -53,7 +54,7 @@ func (emailController *EmailController) Get(c *gin.Context) {
 		})
 		return
 	}
-	c.Set("userInfo", jwtUserInfo)
+	c.Set(types.JWTUserCredentialsKey, jwtUserCredentials)
 
 	controller.Server.VerifyEmail(c)
 }


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR contains the following changes -

- changing structure of jwt user from `PublicUserInfo` to `UserCredentials`
- changing key of jwtUser from `userInfo` to `userCredentials`
- restrict merging part before updating user just to API Request and not for normal updation that we go through for other API calls as well.


We need this PR because -

- In our database  we store the struct `UserCredentials` and normally we update a user by editing his info extracted from `jwtUserInfo` variable which is of struct type `PublicUserInfo`. So if we update this struct type in our database. There is a possibility of losing `password` as `PublicUserInfo` does not contains `password`.

- And we need to merge 2 users before updation just for the external request for updation as for rest of the users we can directly do it by editing `jwtUser` as it already contains all the user details.