### PR TITLE
Skip image build & push on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
           # Ref: https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute
           when: always
       - run:
+          name: Skip image building for pull requests
+          command: if [[ -n "$CIRCLE_PULL_REQUEST" ]] ; then circleci-agent step halt; fi
+      - run:
           name: Build Image
           command: make build IMGTAG=${IMGTAG}
       - run:


### PR DESCRIPTION
## TODOs
- I'll later refactor CircleCI to use container executors & convenience images for golang which might help the builds end a bit faster.

(Q) Is it okay if we skip the `go build`?
(A) Yes, because `go test -cover ./...` would have already built it

```
The idea is simple: Rewrite the package's source code before compilation to add instrumentation, compile and run the modified source, and dump the statistics.
```
Read more: https://blog.golang.org/cover

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>