### PR TITLE
(feat): Signup API for email auth

### DIFF
--- a/manager/emailmanager/email.go
+++ b/manager/emailmanager/email.go
@@ -1,0 +1,40 @@
+package emailmanager
+
+import (
+	"time"
+
+	log "github.com/golang/glog"
+
+	"github.com/mayadata-io/kubera-auth/manager/jwtmanager"
+	"github.com/mayadata-io/kubera-auth/pkg/generates"
+	"github.com/mayadata-io/kubera-auth/pkg/models"
+	"github.com/mayadata-io/kubera-auth/pkg/types"
+)
+
+func SendVerificationEmail(accessGenerate *generates.JWTAccessGenerate, userInfo *models.PublicUserInfo) error {
+	tgr := &jwtmanager.TokenGenerateRequest{
+		UserInfo:       userInfo,
+		AccessTokenExp: time.Minute * types.VerificationLinkExpirationTimeUnit,
+	}
+
+	tokenInfo, err := jwtmanager.GenerateAuthToken(accessGenerate, tgr, models.TokenVerify)
+	if err != nil {
+		return err
+	}
+
+	link := types.PortalURL + "/api/auth/v1/email?access=" + tokenInfo.Access
+
+	buf, err := generates.GetEmailBody(userInfo.GetName(), link)
+	if err != nil {
+		log.Error("Error occurred while getting email body for user: " + userInfo.GetUID() + "error: " + err.Error())
+		return err
+	}
+
+	err = generates.SendEmail(userInfo.GetUnverifiedEmail(), "Email Verification", buf.String())
+	if err != nil {
+		log.Error("Error occurred while sending email for user: " + userInfo.GetUID() + "error: " + err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/manager/usermanager/createUser.go
+++ b/manager/usermanager/createUser.go
@@ -29,23 +29,21 @@ func CreateUser(userStore *store.UserStore, user *models.UserCredentials) (*mode
 
 	password := string(hashedPassword)
 	uid := uuid.Must(uuid.NewRandom()).String()
-	var role models.Role
-	if user.GetRole() != "" {
-		role = user.Role
+	var newUser *models.UserCredentials
+	if user.GetRole() == models.RoleAdmin {
+		newUser = user
 	} else {
-		role = models.RoleUser
-	}
-
-	newUser := &models.UserCredentials{
-		UID:             &uid,
-		UserName:        user.UserName,
-		Password:        &password,
-		Name:            user.Name,
-		UnverifiedEmail: user.UserName,
-		Kind:            models.LocalAuth,
-		Role:            role,
-		OnBoardingState: models.BoardingStateSignup,
-		CreatedAt:       &time.Time{},
+		newUser = &models.UserCredentials{
+			UID:             &uid,
+			UserName:        user.UserName,
+			Password:        &password,
+			Name:            user.Name,
+			UnverifiedEmail: user.UserName,
+			Kind:            models.LocalAuth,
+			Role:            models.RoleUser,
+			OnBoardingState: models.BoardingStateSignup,
+			CreatedAt:       &time.Time{},
+		}
 	}
 
 	err = userStore.Set(newUser)

--- a/manager/usermanager/updateUser.go
+++ b/manager/usermanager/updateUser.go
@@ -12,9 +12,27 @@ import (
 
 // UpdateUserDetails get the user information
 func UpdateUserDetails(userStore *store.UserStore, user *models.UserCredentials) (*models.PublicUserInfo, error) {
-	// This is just for github auth. Will implement a switch  case here once we have a self signup
-	if user.OnBoardingState == models.BoardingStateEmailVerified && user.Kind == models.GithubAuth {
-		user.OnBoardingState = models.BoardingStateVerifiedAndComplete
+	switch user.OnBoardingState {
+	case models.BoardingStateSignup:
+		{
+			if user.Email != nil {
+				user.OnBoardingState = models.BoardingStateEmailVerified
+			} else if user.Company != nil {
+				user.OnBoardingState = models.BoardingStateUnverifiedAndComplete
+			}
+		}
+	case models.BoardingStateEmailVerified:
+		{
+			if user.Company != nil {
+				user.OnBoardingState = models.BoardingStateVerifiedAndComplete
+			}
+		}
+	case models.BoardingStateUnverifiedAndComplete:
+		{
+			if user.Email != nil {
+				user.OnBoardingState = models.BoardingStateVerifiedAndComplete
+			}
+		}
 	}
 
 	err := userStore.UpdateUser(user)

--- a/manager/usermanager/updateUser.go
+++ b/manager/usermanager/updateUser.go
@@ -10,8 +10,11 @@ import (
 	"github.com/mayadata-io/kubera-auth/pkg/types"
 )
 
-// UpdateUserDetails get the user information
+// UpdateUserDetails updates the user information
 func UpdateUserDetails(userStore *store.UserStore, user *models.UserCredentials) (*models.PublicUserInfo, error) {
+	// There will be following possible transitions of OnboardingState
+	// BoardingStateSignup -> BoardingStateEmailVerified -> BoardingStateVerifiedAndComplete
+	// BoardingStateSignup -> BoardingStateUnverifiedAndComplete -> BoardingStateVerifiedAndComplete
 	switch user.OnBoardingState {
 	case models.BoardingStateSignup:
 		{
@@ -39,7 +42,7 @@ func UpdateUserDetails(userStore *store.UserStore, user *models.UserCredentials)
 	return user.GetPublicInfo(), err
 }
 
-// UpdatePassword get the user information
+// UpdatePassword sets the user password
 func UpdatePassword(userStore *store.UserStore, reset bool, oldPassword, newPassword, userID string) (*models.PublicUserInfo, error) {
 	var storedUser *models.UserCredentials
 	var err error

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -79,13 +79,13 @@ var adminUID = uuid.Must(uuid.NewRandom()).String()
 
 //DefaultUser is the admin user created by default
 var DefaultUser = &UserCredentials{
-	UID:      &adminUID,
-	Name:     &types.DefaultName,
-	Email:    &types.DefaultEmail,
-	UserName: &types.DefaultUserName,
-	Password: &types.DefaultUserPassword,
-	Role:     RoleAdmin,
-	Kind:     LocalAuth,
+	UID:             &adminUID,
+	Name:            &types.DefaultName,
+	UnverifiedEmail: &types.DefaultUserName,
+	UserName:        &types.DefaultUserName,
+	Password:        &types.DefaultUserPassword,
+	Role:            RoleAdmin,
+	Kind:            LocalAuth,
 }
 
 //PublicUserInfo displays the information of the user that is publicly available

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -81,11 +81,11 @@ var adminUID = uuid.Must(uuid.NewRandom()).String()
 var DefaultUser = &UserCredentials{
 	UID:             &adminUID,
 	Name:            &types.DefaultName,
-	UnverifiedEmail: &types.DefaultUserName,
 	UserName:        &types.DefaultUserName,
 	Password:        &types.DefaultUserPassword,
 	Role:            RoleAdmin,
 	Kind:            LocalAuth,
+	OnBoardingState: BoardingStateUnverifiedAndComplete,
 }
 
 //PublicUserInfo displays the information of the user that is publicly available

--- a/router/router.go
+++ b/router/router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mayadata-io/kubera-auth/versionedController/v1/email"
 	"github.com/mayadata-io/kubera-auth/versionedController/v1/login"
 	"github.com/mayadata-io/kubera-auth/versionedController/v1/password"
+	"github.com/mayadata-io/kubera-auth/versionedController/v1/signup"
 	"github.com/mayadata-io/kubera-auth/versionedController/v1/user"
 )
 
@@ -31,6 +32,7 @@ var (
 		password.New(),
 		configuration.New(),
 		email.New(),
+		signup.New(),
 	}
 	unauthenticatedLinks = map[string][]string{
 		"/v1" + v1.TokenRoute:         {http.MethodPost, http.MethodGet},
@@ -38,6 +40,7 @@ var (
 		"/v1" + "/oauth":              {http.MethodGet},
 		"/v1" + v1.ConfigurationRoute: {http.MethodGet},
 		"/v1" + healthCheckRoute:      {http.MethodGet},
+		"/v1" + v1.SignupRoute:        {http.MethodPost},
 	}
 )
 

--- a/versionedController/v1/email/email.go
+++ b/versionedController/v1/email/email.go
@@ -54,7 +54,7 @@ func (emailController *EmailController) Get(c *gin.Context) {
 			"error": err.Error(),
 		})
 		// Redirecting user back to UI if access token is not valid
-		c.Redirect(http.StatusUnauthorized, redirectURL)
+		c.Redirect(http.StatusPermanentRedirect, redirectURL)
 		return
 	}
 	c.Set(types.JWTUserCredentialsKey, jwtUserCredentials)

--- a/versionedController/v1/routes.go
+++ b/versionedController/v1/routes.go
@@ -1,9 +1,10 @@
 package v1
 
 const (
-	TokenRoute         string = "/token"
-	UserRoute          string = "/user"
-	PasswordRoute      string = "/password"
-	ConfigurationRoute string = "/configuration"
-	EmailRoute         string = "/email"
+	TokenRoute         = "/token"
+	UserRoute          = "/user"
+	PasswordRoute      = "/password"
+	ConfigurationRoute = "/configuration"
+	EmailRoute         = "/email"
+	SignupRoute        = "/signup"
 )

--- a/versionedController/v1/signup/signup.go
+++ b/versionedController/v1/signup/signup.go
@@ -10,7 +10,7 @@ import (
 	controller "github.com/mayadata-io/kubera-auth/versionedController/v1"
 )
 
-//SignupController is the type the request in which the request will be parsed
+//SignupController is the extension to GenericController which contains the path of this endpoint too.
 type SignupController struct {
 	controller.GenericController
 	routePath string
@@ -32,8 +32,8 @@ func New() *SignupController {
 
 //Post registers a user in database taking minimal details needed
 func (signupController *SignupController) Post(c *gin.Context) {
-	signuplModel := &Model{}
-	err := c.BindJSON(signuplModel)
+	signupModel := &Model{}
+	err := c.BindJSON(signupModel)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusNotAcceptable, gin.H{
@@ -43,9 +43,9 @@ func (signupController *SignupController) Post(c *gin.Context) {
 	}
 
 	newUser := &models.UserCredentials{
-		UserName: &signuplModel.UnverifiedEmail,
-		Name:     &signuplModel.Name,
-		Password: &signuplModel.Password,
+		UserName: &signupModel.UnverifiedEmail,
+		Name:     &signupModel.Name,
+		Password: &signupModel.Password,
 	}
 
 	// First create the user then immediately send a verification link to his email

--- a/versionedController/v1/signup/signup.go
+++ b/versionedController/v1/signup/signup.go
@@ -1,0 +1,58 @@
+package signup
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/golang/glog"
+
+	"github.com/mayadata-io/kubera-auth/pkg/models"
+	controller "github.com/mayadata-io/kubera-auth/versionedController/v1"
+)
+
+//SignupController is the type the request in which the request will be parsed
+type SignupController struct {
+	controller.GenericController
+	routePath string
+}
+
+// Model defines the json struct in which the request will be parsed
+type Model struct {
+	UnverifiedEmail string `json:"unverified_email"`
+	Password        string `json:"password"`
+	Name            string `json:"name"`
+}
+
+// New creates a new LoginUser
+func New() *SignupController {
+	return &SignupController{
+		routePath: controller.SignupRoute,
+	}
+}
+
+//Post registers a user in database taking minimal details needed
+func (signupController *SignupController) Post(c *gin.Context) {
+	signuplModel := &Model{}
+	err := c.BindJSON(signuplModel)
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusNotAcceptable, gin.H{
+			"error": "Unable to parse JSON",
+		})
+		return
+	}
+
+	newUser := &models.UserCredentials{
+		UserName: &signuplModel.UnverifiedEmail,
+		Name:     &signuplModel.Name,
+		Password: &signuplModel.Password,
+	}
+
+	// First create the user then immediately send a verification link to his email
+	controller.Server.SelfSignupUser(c, newUser)
+}
+
+// Register will rsgister this controller to the specified router
+func (signupController *SignupController) Register(router *gin.RouterGroup) {
+	controller.RegisterController(router, signupController, signupController.routePath)
+}


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR consists of following changes -

- Implement signup endpoint as `/v1/signup`
- Change boarding states based on the signup flow
- Introduce `emailmanager` in between server 

The Request-Response will be looking like this
![Screenshot from 2021-03-11 01-33-32](https://user-images.githubusercontent.com/50315249/110690376-df716800-8209-11eb-96d4-ce13b9f87689.png)

The user will be looking like this
```
    {
        "_id": "604928a64eecb313e3d18793",
        "uid": "7b02d6f7-f82a-43c9-817e-98cd9a6fce13",
        "username": "sanjay.nathani@mayadata.io",
        "email": null,
        "unverified_email": "sanjay.nathani@mayadata.io",
        "name": "Sanjay Nathani",
        "kind": "local",
        "role": "user",
        "logged_in": true,
        "created_at": "2021-03-10T20:14:30.722Z",
        "updated_at": "2021-03-10T20:14:44.257Z",
        "removed_at": null,
        "state": "",
        "onboarding_state": 1
    }
```