### PR TITLE
(fix): getting the response as updated user for change email API 

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -372,9 +372,7 @@ func (s *Server) SendVerificationLink(c *gin.Context, unverifiedEmail string) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"message": "Verification email sent",
-	})
+	s.redirect(c, jwtUserCredentials.GetPublicInfo())
 }
 
 // VerifyEmail marks a user email as verified


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR contains following changes -

- POST request to `/v1/email` will be giving this type of response
```
{
    "_id": "604928a64eecb313e3d18793",
    "uid": "7b02d6f7-f82a-43c9-817e-98cd9a6fce13",
    "username": "sanjay.nathani@mayadata.io",
    "email": null,
    "unverified_email": "sanjay.nathani@mayadata.io",
    "name": "Sanjay Nathani",
    "kind": "local",
    "role": "user",
    "logged_in": true,
    "created_at": "2021-03-10T20:14:30.722Z",
    "updated_at": "2021-03-11T16:20:19.693458873+05:30",
    "removed_at": null,
    "state": "",
    "onboarding_state": 1
}
```