### PR TITLE
resend and restore email API

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -422,7 +422,11 @@ func (s *Server) VerifyEmail(c *gin.Context, redirectURL string) {
 	c.Redirect(http.StatusPermanentRedirect, redirectURL)
 }
 
-// RestoreEmail restores the previous email in case user does not want to verify new email
+// RestoreEmail makes the `UnverifiedEmail` as blank.
+// A user might want to change his email and later changes his mind and
+// wants to continue with his previous email only. Since change of email in DB
+// is withhold until the user verifies his new email. So this just removes
+// his unverified email from DB and let the user continue with the verified one.
 func (s *Server) RestoreEmail(c *gin.Context) {
 	jwtUser, exists := c.Get(types.JWTUserCredentialsKey)
 	if !exists {

--- a/versionedController/v1/email/email.go
+++ b/versionedController/v1/email/email.go
@@ -18,6 +18,8 @@ type EmailController struct {
 //Model ...
 type Model struct {
 	UnverifiedEmail string `json:"unverified_email,omitempty"`
+	Resend          bool   `json:"resend,omitempty"`
+	Restore         bool   `json:"restore,omitempty"`
 }
 
 // New creates a new User
@@ -39,7 +41,11 @@ func (emailController *EmailController) Post(c *gin.Context) {
 		return
 	}
 
-	controller.Server.SendVerificationLink(c, emailModel.UnverifiedEmail)
+	if emailModel.Restore {
+		controller.Server.RestoreEmail(c)
+	} else {
+		controller.Server.SendVerificationLink(c, emailModel.Resend, emailModel.UnverifiedEmail)
+	}
 }
 
 //Get verifies the email by a link


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR contains following changes

- resend email API
```
{
resend: true
}
```
Request will be of POST type on /v1/email` endpoint

- restore email API
```
{
restore: true
}
```
Request will be of POST type on /v1/email` endpoint

So now we can send these many data on `/v1/email` endpoint
```
{
resend: -
restore: -
unverified_email: -
}
```

Priority on these data will be below
restore > resend > unverified_email
