### PR TITLE
Add logic to update user.Photo on every login

### DIFF
--- a/manager/loginmanager/login.go
+++ b/manager/loginmanager/login.go
@@ -48,8 +48,11 @@ func SocialLoginUser(userStore *store.UserStore, accessGenerate *generates.JWTAc
 		// Error other than user exists
 		return nil, err
 	} else {
-		// If user exists
+		// If user exists, set loggedIn to true & update photo
 		storedUser.LoggedIn = true
+		if user.Photo != "" {
+			storedUser.Photo = user.Photo
+		}
 		err = userStore.UpdateUser(storedUser)
 		if err != nil {
 			return nil, err

--- a/pkg/oauth/providers/github.go
+++ b/pkg/oauth/providers/github.go
@@ -38,6 +38,7 @@ func getGitHubUser(c *gin.Context, token *oauth2.Token) (*models.UserCredentials
 		LoggedIn:     true,
 		SocialAuthID: strconv.FormatInt(*githubUser.ID, 10),
 		CreatedAt:    &currTime,
+		Photo:        githubUser.GetAvatarURL(),
 	}
 
 	for _, githubUserEmail := range githubUserEmails {

--- a/versionedController/v1/login/login.go
+++ b/versionedController/v1/login/login.go
@@ -71,7 +71,6 @@ func (login *LoginController) Get(c *gin.Context) {
 		if !controller.Server.Config.DisableGoogleAuth {
 			googleURL := controller.Server.GoogleConfig.AuthCodeURL(types.GoogleState,
 				oauth2.SetAuthURLParam("include_granted_scopes", "true"), oauth2.AccessTypeOnline)
-			log.Info(googleURL)
 			c.Redirect(http.StatusFound, googleURL)
 		} else {
 			c.JSON(http.StatusBadRequest, gin.H{


### PR DESCRIPTION
This helps avoid refreshing the userinfo from the Oauth
provider.

(Q) Why is this required?
(A) Currently UI doesn't show the user profile photo from the user, from now on the user endpoint will get the `pictureUrl` field which will have the URL of user's photo(for Github & Google Oauth types only). This will be replaced with the newer url from the oauth provider each time the end-user logs in.

(Q) If a user updates their photo, does this get updated?
(A) Currently for GitHub, the user profile is hosted at a fixed URL i.e. https://avatars.githubusercontent.com/u/{GITHUB_NUMERIC_ID}, for google it's something like https://lh3.googleusercontent.com/<lots of subpaths>/photo.jpg both of them get updated when user changes it. The update of the photo is done to ensure that UI doesn't get a URL which returns a 404.

Signed-off-by: Harsh Vardhan <harsh59v@gmail.com>