### PR TITLE
(fix): marking state as active after first password updation

### DIFF
--- a/manager/usermanager/updateUser.go
+++ b/manager/usermanager/updateUser.go
@@ -57,6 +57,10 @@ func UpdatePassword(userStore *store.UserStore, newPassword, userID string) (*mo
 	}
 	storedUser.Password = string(hashedPassword)
 
+	if storedUser.State == models.StateCreated {
+		storedUser.State = models.StateActive
+	}
+
 	err = userStore.UpdateUser(storedUser)
 	return storedUser.GetPublicInfo(), err
 }


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR fixes following -

- Marks a user as active after the first time his password is updated.

This fix is for UI(Kubera-core) purposes