### PR TITLE
handling duplicate emails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
+	golang.org/x/text v0.3.5 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	k8s.io/apimachinery v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL9
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
@@ -140,6 +141,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -182,9 +184,11 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -210,6 +214,7 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -221,6 +226,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
@@ -363,6 +369,8 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
+golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -413,6 +421,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -493,6 +502,7 @@ gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gG
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -508,6 +518,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/manager/loginmanager/login.go
+++ b/manager/loginmanager/login.go
@@ -1,7 +1,6 @@
 package loginmanager
 
 import (
-	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"golang.org/x/crypto/bcrypt"
 
@@ -25,7 +24,7 @@ func LocalLoginUser(userStore *store.UserStore, accessGenerate *generates.JWTAcc
 		return nil, err
 	}
 
-	storedUser, err := userStore.GetUser(bson.M{"username": username, "kind": models.LocalAuth})
+	storedUser, err := usermanager.GetUser(userStore, bson.M{"username": username, "kind": models.LocalAuth})
 	if err != nil {
 		return nil, err
 	}
@@ -36,18 +35,8 @@ func LocalLoginUser(userStore *store.UserStore, accessGenerate *generates.JWTAcc
 // SocialLoginUser get the user information
 func SocialLoginUser(userStore *store.UserStore, accessGenerate *generates.JWTAccessGenerate, user *models.UserCredentials) (*models.Token, error) {
 	query := bson.M{"social_auth_id": user.SocialAuthID, "kind": user.Kind}
-	storedUser, err := userStore.GetUser(query)
-	if err != nil && err == mgo.ErrNotFound {
-		// If user does not exists
-		createErr := usermanager.CreateSocialUser(userStore, user)
-		if createErr != nil {
-			return nil, createErr
-		}
-		storedUser = user
-	} else if err != nil {
-		// Error other than user exists
-		return nil, err
-	} else {
+	storedUser, err := usermanager.GetUser(userStore, query)
+	if err == nil && storedUser != nil {
 		// If user exists, set loggedIn to true & update photo
 		storedUser.LoggedIn = true
 		if user.Photo != "" {
@@ -57,6 +46,16 @@ func SocialLoginUser(userStore *store.UserStore, accessGenerate *generates.JWTAc
 		if err != nil {
 			return nil, err
 		}
+	} else if err == errors.ErrInvalidUser {
+		// If user does not exists
+		createErr := usermanager.CreateSocialUser(userStore, user)
+		if createErr != nil {
+			return nil, createErr
+		}
+		storedUser = user
+	} else {
+		// Error other than user exists
+		return nil, err
 	}
 
 	tgr := &jwtmanager.TokenGenerateRequest{

--- a/manager/loginmanager/login.go
+++ b/manager/loginmanager/login.go
@@ -47,7 +47,7 @@ func SocialLoginUser(userStore *store.UserStore, accessGenerate *generates.JWTAc
 			return nil, err
 		}
 	} else if err == errors.ErrInvalidUser {
-		// If user does not exists
+		// If user does not exist
 		createErr := usermanager.CreateSocialUser(userStore, user)
 		if createErr != nil {
 			return nil, createErr

--- a/manager/usermanager/createUser.go
+++ b/manager/usermanager/createUser.go
@@ -1,6 +1,8 @@
 package usermanager
 
 import (
+	"time"
+
 	"github.com/globalsign/mgo/bson"
 	"golang.org/x/crypto/bcrypt"
 
@@ -88,6 +90,8 @@ func CreateSocialUser(userStore *store.UserStore, user *models.UserCredentials) 
 	for err != errors.ErrInvalidUser {
 		user.UserName = generateUserName(user.Name)
 		_, err = GetUserByUserName(userStore, user.UserName)
+		// A 100ms sleep will help the CPU to context-switch for other requests in case this loop becomes an infinite loop.
+		time.Sleep(time.Millisecond * 100)
 	}
 	user.UID = uuid.Must(uuid.NewRandom()).String()
 

--- a/manager/usermanager/createUser.go
+++ b/manager/usermanager/createUser.go
@@ -70,15 +70,24 @@ func CreateUser(userStore *store.UserStore, user *models.UserCredentials, isSign
 func CreateSocialUser(userStore *store.UserStore, user *models.UserCredentials) error {
 	userWithSameEmail, err := GetUser(userStore, bson.M{"email": user.Email})
 	if err == nil && userWithSameEmail != nil {
+		// If a user with this email is already existing then return error
 		return errors.ErrUserExists
 	} else if err != errors.ErrInvalidUser {
+		// If some error occurs other than invalid user (here invalid user
+		// means such a user does not exist)
 		return err
 	}
 
+	// If user with the given email does not exist.
+	// This infinite loop generates a username and checks whether this username
+	// is already existing or not. If it is already existing the loop will go ahead
+	// and try with a different username and if the username is not in use
+	// `break` statement will be executed.
 	for {
 		user.UserName = generateUserName(user.Name)
 		_, err = GetUserByUserName(userStore, user.UserName)
 		if err == errors.ErrInvalidUser {
+			// User does not exist
 			break
 		}
 	}

--- a/manager/usermanager/createUser.go
+++ b/manager/usermanager/createUser.go
@@ -79,17 +79,15 @@ func CreateSocialUser(userStore *store.UserStore, user *models.UserCredentials) 
 	}
 
 	// If user with the given email does not exist.
-	// This infinite loop generates a username and checks whether this username
+	// This loop generates a username and checks whether this username
 	// is already existing or not. If it is already existing the loop will go ahead
 	// and try with a different username and if the username is not in use
 	// `break` statement will be executed.
-	for {
+	user.UserName = generateUserName(user.Name)
+	_, err = GetUserByUserName(userStore, user.UserName)
+	for err != errors.ErrInvalidUser {
 		user.UserName = generateUserName(user.Name)
 		_, err = GetUserByUserName(userStore, user.UserName)
-		if err == errors.ErrInvalidUser {
-			// User does not exist
-			break
-		}
 	}
 	user.UID = uuid.Must(uuid.NewRandom()).String()
 

--- a/manager/usermanager/getUser.go
+++ b/manager/usermanager/getUser.go
@@ -9,19 +9,22 @@ import (
 	"github.com/mayadata-io/kubera-auth/pkg/store"
 )
 
-// GetUserByUserName get the user information
+// GetUserByUserName get the user information based on username
 func GetUserByUserName(userStore *store.UserStore, userName string) (user *models.UserCredentials, err error) {
 	query := bson.M{"username": userName}
-	user, err = userStore.GetUser(query)
-	if err != nil && err == mgo.ErrNotFound {
-		err = errors.ErrInvalidUser
-	}
+	user, err = GetUser(userStore, query)
 	return
 }
 
-// GetUserByUID get the user information
+// GetUserByUID get the user information based on uid
 func GetUserByUID(userStore *store.UserStore, userID string) (user *models.UserCredentials, err error) {
 	query := bson.M{"uid": userID}
+	user, err = GetUser(userStore, query)
+	return
+}
+
+//GetUser gets the user information based on the given query
+func GetUser(userStore *store.UserStore, query bson.M) (user *models.UserCredentials, err error) {
 	user, err = userStore.GetUser(query)
 	if err != nil && err == mgo.ErrNotFound {
 		err = errors.ErrInvalidUser

--- a/manager/usermanager/user.go
+++ b/manager/usermanager/user.go
@@ -21,7 +21,8 @@ func IsUserExists(userStore *store.UserStore, user *models.UserCredentials) (boo
 		return false, err
 	}
 
-	if !exists && user.Email != "" {
+	if !exists && user.UnverifiedEmail != "" {
+		// Check if the supplied email is already registered with some other user
 		_, err := userStore.GetUser(bson.M{"email": user.UnverifiedEmail})
 		if err != nil && err == mgo.ErrNotFound {
 			exists = false

--- a/manager/usermanager/user.go
+++ b/manager/usermanager/user.go
@@ -22,7 +22,7 @@ func IsUserExists(userStore *store.UserStore, user *models.UserCredentials) (boo
 	}
 
 	if !exists && user.Email != "" {
-		_, err := userStore.GetUser(bson.M{"email": user.Email})
+		_, err := userStore.GetUser(bson.M{"email": user.UnverifiedEmail})
 		if err != nil && err == mgo.ErrNotFound {
 			exists = false
 		} else if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -368,11 +368,15 @@ func (s *Server) SendVerificationLink(c *gin.Context, resend bool, unverifiedEma
 	}
 	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
+	// Checking if the given email is already registered with some user
 	userWithSameEmail, err := usermanager.GetUser(s.userStore, bson.M{"email": unverifiedEmail})
 	if err == nil && userWithSameEmail != nil {
+		// User with same email exists
 		s.errorResponse(c, errors.ErrUserExists)
 		return
 	} else if err != errors.ErrInvalidUser {
+		// If some error occurs other than invalid user (here invalid user
+		// means such a user does not exist)
 		s.errorResponse(c, err)
 		return
 	}
@@ -410,8 +414,10 @@ func (s *Server) VerifyEmail(c *gin.Context, redirectURL string) {
 	jwtUserCredentials := jwtUser.(*models.UserCredentials)
 
 	if jwtUserCredentials.UnverifiedEmail != "" {
+		// Checking if the given email is already registered with some user
 		userWithSameEmail, err := usermanager.GetUser(s.userStore, bson.M{"email": jwtUserCredentials.UnverifiedEmail})
 		if err == nil && userWithSameEmail != nil {
+			// User with same email exists
 			log.Errorln("Email already in use with another user for user uid: ", jwtUserCredentials.UID)
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "Email already in use with another user",
@@ -419,6 +425,8 @@ func (s *Server) VerifyEmail(c *gin.Context, redirectURL string) {
 			c.Redirect(http.StatusPermanentRedirect, redirectURL)
 			return
 		} else if err != errors.ErrInvalidUser {
+			// If some error occurs other than invalid user (here invalid user
+			// means such a user does not exist)
 			s.errorResponse(c, err)
 			// Redirecting user to UI if email found in field `email` is already present for some user
 			c.Redirect(http.StatusPermanentRedirect, redirectURL)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -288,6 +288,20 @@ func (s *Server) CreateRequest(c *gin.Context, user *models.UserCredentials) {
 		return
 	}
 
+	if user.UnverifiedEmail != "" {
+		storedUser, err := usermanager.GetUser(s.userStore, bson.M{"unverified_email": user.UnverifiedEmail})
+		if err == nil && storedUser != nil {
+			// If user exists
+			s.errorResponse(c, errors.ErrUserExists)
+			return
+		} else if err != errors.ErrInvalidUser {
+			// If some error occurs other than invalid user (here invalid user
+			// means such a user does not exist)
+			s.errorResponse(c, err)
+			return
+		}
+	}
+
 	var createdUserInfo *models.PublicUserInfo
 	var err error
 	if jwtUserCredentials.Role == models.RoleAdmin {

--- a/versionedController/v1/signup/signup.go
+++ b/versionedController/v1/signup/signup.go
@@ -43,9 +43,10 @@ func (signupController *SignupController) Post(c *gin.Context) {
 	}
 
 	newUser := &models.UserCredentials{
-		UserName: signupModel.UnverifiedEmail,
-		Name:     signupModel.Name,
-		Password: signupModel.Password,
+		UserName:        signupModel.UnverifiedEmail,
+		Name:            signupModel.Name,
+		Password:        signupModel.Password,
+		UnverifiedEmail: signupModel.UnverifiedEmail,
 	}
 
 	// First create the user then immediately send a verification link to his email


### PR DESCRIPTION
Signed-off-by: Sanjay Nathani <sanjay.nathani@mayadata.io>

This PR adds a duplicate email check in following API's

- Change Email API (while sending email as well as while verifying email)
  Here the email will be checked 2 times
  - While sending the verification email to new email. Here the new email (unverified_email) will be checked against the `email` field of existing users to ensure no user has that email registered with him.
  - While verifying email (moving email_address from `unverified_email` field to `email` field). Here also this email will be checked again against the `email` field of all existing users in order to ensure that no user has registered with that email in between.
 

- SelfSignup API
  Check the given email(as unverified_email) against all the emails of existing users

- OAuth signup
  Check the email extracted from social auth is existing or not 
