### PR TITLE
Add logic for incremental container image tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
         # The image tagging logic goes here, the env variables aren't exported to further steps
           name: "Build a docker image"
           command: |
-            [[ $CIRCLE_BRANCH == TechPreview* ]] && export IMGTAG=$CIRCLE_BRANCH || export IMGTAG="master-ci"
+            [[ $CIRCLE_BRANCH == TechPreview* ]] && export IMGTAG=$CIRCLE_BRANCH || export IMGTAG=$CIRCLE_BRANCH-<< pipeline.number >>
             # Build the image with $IMGTAG
             make build
             docker push mayadataio/kubera-auth:$IMGTAG


### PR DESCRIPTION
Benefits:
- Easier to debug, an image tag will have a relation to code via the CI
  build logs. The pipeline numbers are incremental, so it'd be easy
  to tell apart newer image from older one. Fixed tags like latest
  aren't a good idea.
- ImagePullPolicy need not be set to always, a code change will require
  an image tag to get deployed.

# Opinions

These are biased and my own, these aren't from a well defined set of good practices
Container images should have a direct mapping with the code by the virtue of tags, the image tags could be
- short commit hash of the code from which it is built
- have the git tag if the commit has a tag
- have other release specific tags(can lead to problems if there are different series of tags)

Reasons why I'm a bit against circleCI tags
- They don't communicate qualitative information about the source-code but casually suggest image-history, etc
- Later we might decide to jump to jenkins/github actions which would make the current tagging logic meaningless(the build logs might get cleared if we just stop building)
- Circleci might have a log retention policy for builds, so if we'd need to figure out which code commit is this image built from, things wouldn't be simple and we'd be at a losing end if the logs are removed.

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>