### PR TITLE
Pass processing errors for Oauth callbacks in queryparams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Build Files
 output/
-server
 .idea
+./server
 coverage.txt
 vendor/

--- a/pkg/oauth/providers/github.go
+++ b/pkg/oauth/providers/github.go
@@ -42,7 +42,7 @@ func getGitHubUser(c *gin.Context, token *oauth2.Token) (*models.UserCredentials
 	}
 
 	for _, githubUserEmail := range githubUserEmails {
-		if githubUserEmail.Primary != nil && githubUserEmail.Email != nil {
+		if githubUserEmail.Primary != nil && *githubUserEmail.Primary {
 			user.Email = githubUserEmail.GetEmail()
 			user.OnBoardingState = models.BoardingStateEmailVerified
 			break

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,7 +97,12 @@ func (s *Server) SocialLoginRequest(c *gin.Context, user *models.UserCredentials
 	tokenInfo, err := loginmanager.SocialLoginUser(s.userStore, s.accessGenerate, user)
 	if err != nil {
 		log.Errorln("Error logging in ", err)
-		c.Redirect(http.StatusConflict, types.PortalURL+"?error="+errors.ErrUserExists.Error())
+		// Below stuff solves the problem but gives an inappropriate status code
+		c.Redirect(http.StatusTemporaryRedirect, types.PortalURL+"/login?error="+errors.ErrUserExists.Error())
+		// Below stuff doesn't solve the problem but gives correct status code
+		// c.JSON(http.StatusInternalServerError, gin.H{
+		// 	"error": errors.ErrUserExists.Error(),
+		// })
 		return
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,7 +97,7 @@ func (s *Server) SocialLoginRequest(c *gin.Context, user *models.UserCredentials
 	tokenInfo, err := loginmanager.SocialLoginUser(s.userStore, s.accessGenerate, user)
 	if err != nil {
 		log.Errorln("Error logging in ", err)
-		s.errorResponse(c, err)
+		c.Redirect(http.StatusConflict, types.PortalURL+"?error="+errors.ErrUserExists.Error())
 		return
 	}
 


### PR DESCRIPTION
If the error object is just written in the response, the JSON will get
shown in the UI and the JS code will not have a way to show the error in
a box as the callback request body is being written.

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>